### PR TITLE
Makefile: Add riscv64-linux-user to the targets and add static

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,7 +194,8 @@ $(qemu): $(qemu_srcdir)
 	mkdir -p $(dir $@)
 	cd $(qemu_wrkdir) && $</configure \
 		--prefix=$(dir $(abspath $(dir $@))) \
-		--target-list=riscv64-softmmu
+		--static \
+		--target-list=riscv64-softmmu,riscv64-linux-user
 	$(MAKE) -C $(qemu_wrkdir)
 	$(MAKE) -C $(qemu_wrkdir) install
 	touch -c $@


### PR DESCRIPTION
To assist in the generation of a rootfs for Debian using debootstrap we
add the riscv64-linux-user to the qemu build. We also add the static
flag as that is needed to make this work.

Signed-off-by: Stephen Bates <sbates@raithlin.com>